### PR TITLE
Replace &nbsp; in week text from cors page

### DIFF
--- a/tasks/cors.js
+++ b/tasks/cors.js
@@ -86,7 +86,7 @@ module.exports = function (grunt) {
                 return {
                   ClassNo: row.eq(0).text().trim(),
                   LessonType: row.eq(1).text(),
-                  WeekText: row.eq(2).text(),
+                  WeekText: row.eq(2).text().replace(/\u00a0/g, ' '),
                   DayText: row.eq(3).text(),
                   StartTime: row.eq(4).text(),
                   EndTime: row.eq(5).text(),


### PR DESCRIPTION
So for some reason, there is an `&nbsp;` between the week text: "EVERY&nbsp;WEEK", inspect element at https://myaces.nus.edu.sg/cors/jsp/report/ModuleDetailedInfo.jsp?acad_y=2016/2017&sem_c=2&mod_c=ACC1002.

This will cause problems when we are doing comparison of week text, for example when exporting ical, we check week text to see if it is "odd week", "even week", "every week", which will always fail since we check for space, but it actually is a `&nbsp;`.

You can verify this by adding a module, e.g. CS42515, and see that it gets exported as a "Odd week" timetable.